### PR TITLE
Cache the CI build with vite-task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,28 @@ jobs:
       - uses: voidzero-dev/setup-vp@v1
         with:
           cache: true
-      # Build first: it generates .void/routes.d.ts and queues.d.ts, which the
-      # generated .void/tsconfig.json references. Since vite-plus 0.2.2,
-      # vp check fails on the invalid tsconfig when those files are missing
-      # (vp config alone does not create them on a fresh checkout).
-      - run: vp run build
+      # Restore the vite-task result cache so unchanged builds replay instead
+      # of rebuilding. The primary key is unique per run (entries are
+      # immutable); restore-keys falls back to the newest compatible entry.
+      - uses: actions/cache/restore@v6
+        with:
+          path: node_modules/.vite/task-cache
+          key: vite-task-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: vite-task-${{ runner.os }}-${{ runner.arch }}-
+      # Build first (via the cacheable ci-build task): it generates
+      # .void/routes.d.ts and queues.d.ts, which the generated
+      # .void/tsconfig.json references. Since vite-plus 0.2.2, vp check fails
+      # on the invalid tsconfig when those files are missing (vp config alone
+      # does not create them on a fresh checkout). A cache replay restores
+      # them from the archived task outputs.
+      - run: vp run ci-build
       - run: vp check
       - run: vp test run
+      - uses: actions/cache/save@v6
+        if: always()
+        with:
+          path: node_modules/.vite/task-cache
+          key: vite-task-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}-${{ github.run_attempt }}
 
   staging-deploy:
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,11 @@ jobs:
       # otherwise invalidate the cache on every run. A sanitized, stable
       # environment makes the fingerprint reproducible.
       - run: env -i PATH="$PATH" HOME="$HOME" vp run build
-      - run: vp check
+      # Cached check task. Must run after the direct `vp run build` above:
+      # build entries stored by a dependency execution do not archive outputs,
+      # so the direct build step is what guarantees .void type declarations
+      # exist before type-aware checking.
+      - run: env -i PATH="$PATH" HOME="$HOME" vp run check
       - run: vp test run
       - uses: actions/cache/save@v6
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,19 @@ jobs:
           path: node_modules/.vite/task-cache
           key: vite-task-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: vite-task-${{ runner.os }}-${{ runner.arch }}-
-      # Build first (via the cacheable ci-build task): it generates
+      # Build first (via the cacheable build task): it generates
       # .void/routes.d.ts and queues.d.ts, which the generated
       # .void/tsconfig.json references. Since vite-plus 0.2.2, vp check fails
       # on the invalid tsconfig when those files are missing (vp config alone
       # does not create them on a fresh checkout). A cache replay restores
       # them from the archived task outputs.
-      - run: vp run ci-build
+      #
+      # env -i: the build enumerates process.env (void env filtering), and
+      # vite-task fingerprints that bulk query against the unfiltered parent
+      # environment, so per-run variables like ACTIONS_ORCHESTRATION_ID would
+      # otherwise invalidate the cache on every run. A sanitized, stable
+      # environment makes the fingerprint reproducible.
+      - run: env -i PATH="$PATH" HOME="$HOME" vp run build
       - run: vp check
       - run: vp test run
       - uses: actions/cache/save@v6

--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ Notes:
 - Void OIDC only accepts push events as deploy triggers, so PRs cannot deploy previews; staging verification happens after merging to `dev`
 - Each deployed page hides a build stamp in the homepage footer: select the page (Cmd+A) to reveal the deployed commit and build time
 - Inspect deployments with `void project status fengmk2` or `void project status fengmk2-staging`, runtime logs with `void project logs`
-- The CI test job caches vite-task build results (`node_modules/.vite/task-cache`) via GitHub Actions cache, so commits that do not touch build inputs replay the build in under a second; deploys build fresh through `void deploy` and never use this cache
+- The CI test job caches vite-task results (`node_modules/.vite/task-cache`) for the `build` and `check` tasks via GitHub Actions cache, so commits that do not touch their inputs replay in under a second; deploys build fresh through `void deploy` and never use this cache

--- a/README.md
+++ b/README.md
@@ -39,3 +39,4 @@ Notes:
 - Void OIDC only accepts push events as deploy triggers, so PRs cannot deploy previews; staging verification happens after merging to `dev`
 - Each deployed page hides a build stamp in the homepage footer: select the page (Cmd+A) to reveal the deployed commit and build time
 - Inspect deployments with `void project status fengmk2` or `void project status fengmk2-staging`, runtime logs with `void project logs`
+- The CI test job caches vite-task build results (`node_modules/.vite/task-cache`) via GitHub Actions cache, so commits that do not touch build inputs replay the build in under a second; deploys build fresh through `void deploy` and never use this cache

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "type": "module",
   "scripts": {
     "dev": "vp dev",
-    "build": "vp build",
     "preview": "vp preview",
     "prepare": "vp config"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -91,15 +91,17 @@ export default defineConfig({
   run: {
     tasks: {
       // Cacheable build task for CI (the test job restores
-      // node_modules/.vite/task-cache and runs `vp run ci-build`). A task may
-      // not shadow the package.json `build` script, hence the distinct name.
-      // Auto input tracking with excludes for paths the build itself writes
-      // (og images, wrangler config), which would otherwise block cache
-      // storage, and for .git so commits that do not touch build inputs can
-      // replay. Deploy builds go through `void deploy` and never use this
-      // cache, so deployed bundles always get a fresh commit stamp.
-      "ci-build": {
+      // node_modules/.vite/task-cache and runs `vp run build`). There is
+      // deliberately no `build` script in package.json: a task may not shadow
+      // a script of the same name, and void deploy falls back to the
+      // equivalent `vite build` when the script is absent, so deploy builds
+      // never use this cache and always get a fresh commit stamp.
+      build: {
         command: "vp build",
+        // No env fingerprinting: the build enumerates process.env (void env
+        // filtering), which would otherwise fingerprint per-run CI variables
+        // like ACTIONS_ORCHESTRATION_ID and invalidate every run.
+        env: [],
         // Explicit inputs (no auto tracking): fspy-recorded directory entries
         // for generated dirs (.void) invalidate on every fresh checkout even
         // when excluded. Dependency changes are covered by pnpm-lock.yaml.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -88,6 +88,44 @@ function buildTime() {
 }
 
 export default defineConfig({
+  run: {
+    tasks: {
+      // Cacheable build task for CI (the test job restores
+      // node_modules/.vite/task-cache and runs `vp run ci-build`). A task may
+      // not shadow the package.json `build` script, hence the distinct name.
+      // Auto input tracking with excludes for paths the build itself writes
+      // (og images, wrangler config), which would otherwise block cache
+      // storage, and for .git so commits that do not touch build inputs can
+      // replay. Deploy builds go through `void deploy` and never use this
+      // cache, so deployed bundles always get a fresh commit stamp.
+      "ci-build": {
+        command: "vp build",
+        // Explicit inputs (no auto tracking): fspy-recorded directory entries
+        // for generated dirs (.void) invalidate on every fresh checkout even
+        // when excluded. Dependency changes are covered by pnpm-lock.yaml.
+        input: [
+          "blog.config.ts",
+          "env.d.ts",
+          "middleware/**",
+          "package.json",
+          "pages/**",
+          "!pages/posts/**",
+          "pnpm-lock.yaml",
+          "pnpm-workspace.yaml",
+          "posts/**",
+          "public/**",
+          "!public/feed.xml",
+          "!public/og/**",
+          "!public/sitemap.xml",
+          "src/**",
+          "!src/redirects.generated.ts",
+          "tsconfig.json",
+          "vite.config.ts",
+          "void.json",
+        ],
+      },
+    },
+  },
   define: {
     __BUILD_COMMIT__: JSON.stringify(buildCommit()),
     __BUILD_TIME__: JSON.stringify(buildTime()),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -90,6 +90,39 @@ function buildTime() {
 export default defineConfig({
   run: {
     tasks: {
+      // Cacheable vp check. Type-aware linting reads the .void type
+      // declarations that the build generates, hence dependsOn. Inputs cover
+      // everything vp check formats, lints, or type-checks; generated files
+      // are excluded (their sources are tracked), and .void/dev-trigger-token
+      // is a random per-checkout value that would poison the fingerprint.
+      check: {
+        command: "vp check",
+        dependsOn: ["build"],
+        env: [],
+        input: [
+          ".github/**",
+          ".void/**",
+          "!.void/dev-trigger-token",
+          "AGENTS.md",
+          "CLAUDE.md",
+          "README.md",
+          "blog.config.ts",
+          "env.d.ts",
+          "middleware/**",
+          "package.json",
+          "pages/**",
+          "!pages/posts/**",
+          "pnpm-lock.yaml",
+          "pnpm-workspace.yaml",
+          "posts/**",
+          "src/**",
+          "!src/redirects.generated.ts",
+          "tsconfig.json",
+          "vite.config.ts",
+          "vitest.config.ts",
+          "void.json",
+        ],
+      },
       // Cacheable build task for CI (the test job restores
       // node_modules/.vite/task-cache and runs `vp run build`). There is
       // deliberately no `build` script in package.json: a task may not shadow

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -151,6 +151,7 @@ export default defineConfig({
           "public/**",
           "!public/feed.xml",
           "!public/og/**",
+          "!public/posts/**",
           "!public/sitemap.xml",
           "src/**",
           "!src/redirects.generated.ts",


### PR DESCRIPTION
Caches the vite-task results (`node_modules/.vite/task-cache`) for the CI test job via GitHub Actions cache (https://viteplus.dev/guide/github-actions-cache), so commits that do not touch build inputs replay `build` and `check` instead of rerunning them.

## Time saved

Measured on the `test` job, same commit, cold run had all caches deleted first:

| step | cold (no cache) | warm (cache hit) |
| --- | --- | --- |
| setup-vp | 12s | 12s |
| `vp run build` | 20s | 0s |
| `vp run check` | 14s | 1s |
| other (checkout, test, cache restore/save) | 8s | 8s |
| **test job total** | **54s** | **21s** |

About 33s saved (61%), matching vite-task's own `2/2 cache hit (100%), 32.92s saved`. Cache restore/save adds only ~2s, so a cold run pays almost nothing. The warm floor (~21s) is mostly `setup-vp`, which the cache cannot touch.

## Implementation

- `build` and `check` are cacheable vite-task tasks with explicit inputs (auto tracking records generated directories that invalidate every fresh checkout, so inputs are declared; see voidzero-dev/vite-task#504).
- The CI steps run under `env -i PATH="$PATH" HOME="$HOME"` so per-run Actions variables do not bust the cache (see voidzero-dev/vite-task#505).
- The package.json `build` script is removed so the task can own the name. `void deploy` falls back to `vite build`, so deploy builds never use this cache and always get a fresh commit stamp.